### PR TITLE
unitVector / separation fixed !?

### DIFF
--- a/hxcollision/Collision.hx
+++ b/hxcollision/Collision.hx
@@ -233,6 +233,8 @@
             var offset : Float;
             var vectorOffset:Vector2D = new Vector2D();
             var vectors:Array<Vector2D>;
+            var shortestDistance : Float = 0x3FFFFFFF;
+            var collisionData:CollisionData = new CollisionData();
 
             var distance : Float = 0xFFFFFFFF;
             var testDistance : Float = 0x3FFFFFFF;
@@ -338,17 +340,21 @@
                     return null;
                     
                 }
+
+                var distance : Float = -(max2 - min1);
+                if(Math.abs(distance) < shortestDistance) {
+                    collisionData.unitVector = normalAxis;
+                    collisionData.overlap = distance;
+                    shortestDistance = Math.abs(distance);
+                }
                 
             }
             
             //if you made it here, there is a collision!!!!!
-            
-            var collisionData:CollisionData = new CollisionData();
-            collisionData.overlap = -(max2 - min1);
-            collisionData.unitVector = normalAxis;
+            collisionData.unitVector.reverse();
             collisionData.shape1 = polygon;
             collisionData.shape2 = circle;
-            collisionData.separation = new Vector2D(normalAxis.x * (max2 - min1) * -1, normalAxis.y * (max2 - min1) * -1); //return the separation distance
+            collisionData.separation = new Vector2D(collisionData.unitVector.x * collisionData.overlap  , collisionData.unitVector.y * collisionData.overlap ); //return the separation distance
             return collisionData;
         }
         
@@ -359,10 +365,11 @@
             if(distanceSquared < totalRadius * totalRadius) { //if your distance is less than the totalRadius square(because distance is squared)
                 var difference : Float = totalRadius - Math.sqrt(distanceSquared); //find the difference. Square roots are needed here.
                 var collisionData:CollisionData = new CollisionData(); //new CollisionData class to hold all the data for this collision
-                collisionData.separation = new Vector2D((circle2.x - circle1.x) * difference, (circle2.y - circle1.y) * difference); //find the movement needed to separate the circles
                 collisionData.shape1 = circle1;
+                collisionData.shape2 = circle2;
                 collisionData.unitVector = new Vector2D(circle2.x - circle1.x, circle2.y - circle1.y);
                 collisionData.unitVector.normalize();
+                collisionData.separation = new Vector2D(-collisionData.unitVector.x * difference, -collisionData.unitVector.y * difference ); //find the movement needed to separate the circles
                 collisionData.overlap = collisionData.separation.length;
                 return collisionData;
             }
@@ -446,6 +453,7 @@
             }
             
             //if you're here, there is a collision
+            collisionData.unitVector.reverse();
             collisionData.shape1 = polygon1;
             collisionData.shape2 = polygon2;
             collisionData.separation = new Vector2D(collisionData.unitVector.x * collisionData.overlap, collisionData.unitVector.y * collisionData.overlap); //return the separation, apply it to a polygon to separate the two shapes.

--- a/hxcollision/CollisionData.hx
+++ b/hxcollision/CollisionData.hx
@@ -16,11 +16,28 @@
 		public var shape2 : Shape;
 
 			// unit vector on the axis of the collision (the normal of the face that was collided with)
-		public var unitVector : Vector2D; 
-		
+		public var unitVector : Vector2D;
+
 			//Constructor
 		public function new() {
 			separation = new Vector2D(); 
 			unitVector = new Vector2D();
+		}
+
+			//Get the unit vector of the specified shape
+		public function getUnitVectorOf(shape : Shape)
+		{
+			if(shape == shape1)
+				return unitVector;
+			else
+				return new Vector2D(-unitVector.x, -unitVector.y);
+		}
+			//Get the seperation vector of the specified shape
+		public function getSeparationOf(shape : Shape)
+		{
+			if(shape == shape1)
+				return separation;
+			else
+				return new Vector2D(-separation.x, -separation.y);
 		}
 	}

--- a/hxcollision/OpenFLDrawer.hx
+++ b/hxcollision/OpenFLDrawer.hx
@@ -27,6 +27,16 @@ class OpenFLDrawer extends ShapeDrawer {
 
     } //drawLine
 
+    public override function drawVector( p0:Vector2D, p1:Vector2D ) {
+        
+        if(graphics != null) {
+            graphics.moveTo( p0.x, p0.y );
+            graphics.lineTo( p1.x, p1.y);
+            graphics.drawCircle( p1.x, p1.y, 2);
+        } //graphics != null
+
+    } //drawLine
+
     public override function drawCircle( circle:Circle ) { 
 
         if(graphics != null) {

--- a/hxcollision/tests/Main.hx
+++ b/hxcollision/tests/Main.hx
@@ -26,6 +26,7 @@ class Main extends Sprite {
     var collide_color3 : Int = 0x11CC88;
     var collide_color4 : Int = 0xCC55AA;
     var collide_color5 : Int = 0x5500CC;
+    var separation_color : Int = 0xF2903A;
 
         //the mouse position
     var mouse_pos : Point;
@@ -143,11 +144,41 @@ class Main extends Sprite {
 
     } //update_line
 
-    public function draw_collision_response( pos:Vector2D, collision_response:CollisionData ) {
+    public function draw_collision_response( collision_response:CollisionData ) {
+
+        var shape1_origin : Vector2D;
+        var shape1_unit_vector : Vector2D;
+        var shape1_target : Vector2D;
+        var shape1_separation : Vector2D;
+
+        var shape2_origin : Vector2D;
+        var shape2_unit_vector : Vector2D;
+        var shape2_target : Vector2D;
+        var shape2_separation : Vector2D;
+
+            //draw the unit vector pointing to the colliding shape
         visualise.graphics.lineStyle( 1, collide_color3 );
-            
-            drawer.drawLine( new Vector2D(pos.x, pos.y), new Vector2D( pos.x+(collision_response.unitVector.x*20), pos.y+(collision_response.unitVector.y*20) ) );
-    }
+            shape1_origin = collision_response.shape1.position;
+            shape1_unit_vector = collision_response.getUnitVectorOf(collision_response.shape1);
+            shape1_target = new Vector2D( shape1_origin.x+(shape1_unit_vector.x*20), shape1_origin.y+(shape1_unit_vector.y*20) );
+            drawer.drawVector( shape1_origin, shape1_target );
+
+            shape2_origin = collision_response.shape2.position;
+            shape2_unit_vector = collision_response.getUnitVectorOf(collision_response.shape2);
+            shape2_target = new Vector2D( shape2_origin.x+(shape2_unit_vector.x*20), shape2_origin.y+(shape2_unit_vector.y*20) );
+            drawer.drawVector( shape2_origin, shape2_target );
+
+            //draw the separation vector pointing to the opposite direction of the colliding shape
+        visualise.graphics.lineStyle( 1, separation_color );
+            shape1_separation = collision_response.getSeparationOf(collision_response.shape1);
+            shape1_target = new Vector2D( shape1_origin.x+(shape1_separation.x), shape1_origin.y+(shape1_separation.y) );
+            drawer.drawVector( shape1_origin, shape1_target );
+
+            shape2_separation = collision_response.getSeparationOf(collision_response.shape2);
+            shape2_target = new Vector2D( shape2_origin.x+(shape2_separation.x), shape2_origin.y+(shape2_separation.y) );
+            drawer.drawVector( shape2_origin, shape2_target );
+
+    } //draw_collision_response
 
     var end_dt : Float = 0;
     var dt : Float = 0;
@@ -172,7 +203,7 @@ class Main extends Sprite {
 
             if(mouse_collide != null) {
                 mouse_color = collide_color1;
-                draw_collision_response(new Vector2D(circle_static.x, circle_static.y), mouse_collide);
+                draw_collision_response(mouse_collide);
             }
 
         } else { //mouse_is_hexagon
@@ -181,7 +212,7 @@ class Main extends Sprite {
 
             if(mouse_collide != null) {
                 mouse_color = collide_color1;
-                draw_collision_response(new Vector2D(circle_static.x, circle_static.y), mouse_collide);
+                draw_collision_response(mouse_collide);
             }
 
         } //!mouse_is_hexagon else
@@ -194,7 +225,7 @@ class Main extends Sprite {
 
             if(mouse_collide != null) {
                 mouse_color = collide_color5;
-                draw_collision_response(new Vector2D(oct_static.x, oct_static.y), mouse_collide);
+                draw_collision_response(mouse_collide);
             }
 
         } else { //mouse_is_hexagon
@@ -203,7 +234,7 @@ class Main extends Sprite {
 
             if(mouse_collide != null) {
                 mouse_color = collide_color5;
-                draw_collision_response(new Vector2D(oct_static.x, oct_static.y), mouse_collide);
+                draw_collision_response(mouse_collide);
             }
 
         } //!mouse_is_hexagon else
@@ -215,7 +246,7 @@ class Main extends Sprite {
 
             if(mouse_collide != null) {
                 mouse_color = collide_color2;
-                draw_collision_response(new Vector2D(box_static.x, box_static.y), mouse_collide);
+                draw_collision_response(mouse_collide);
             }
 
         } else { //mouse_is_hexagon
@@ -224,7 +255,7 @@ class Main extends Sprite {
 
             if(mouse_collide != null) {
                 mouse_color = collide_color2;
-                draw_collision_response(new Vector2D(box_static.x, box_static.y), mouse_collide);
+                draw_collision_response(mouse_collide);
             }
             
         } //!mouse_is_hexagon else
@@ -235,11 +266,7 @@ class Main extends Sprite {
 
         if(mouse_collide != null) {
             mouse_color = collide_color3;
-            if(mouse_is_hexagon) {
-                draw_collision_response(new Vector2D(circle_mouse.x, circle_mouse.y), mouse_collide);
-            } else {
-                draw_collision_response(new Vector2D(hexagon_mouse.x, hexagon_mouse.y), mouse_collide);
-            }
+            draw_collision_response(mouse_collide);
         }
 
 //Test the line and all the shapes


### PR DESCRIPTION
Your sample was showing the unitVector pointing
to the collided shape with Circles collisions and
at the opposite with other types of collisions.

Polygon to Circle wouldn't return a correct
UnitVector (sample again).

By moving the distance piece of code from
checkPolygons to checkCircleVsPolygon
it ended up working.

There's only one unitVector while several
shapes are colliding and since there's no notion
of order it's a bit confusing to use.

I created two methods in CollisionData.hx
getUnitVectorOf & getSeparationOf so that one can
get a unit/separation vector for a specific
shape.

There were some weird behaviors with separation
in Circle to Circle collisions.

I updated the sample so that it shows vector
directions as well. I also displayed the
separation vector.

I think i remember you were using it for luxe,
so i might be misunderstanding its use or you're
using an updated version of it. In any case it
works for me now so i thought i would at least
let you review it.
