### PR TITLE
Shape rotation fix

### DIFF
--- a/hxcollision/math/Matrix.hx
+++ b/hxcollision/math/Matrix.hx
@@ -44,16 +44,12 @@ class Matrix #if cpp implements cpp.rtti.FieldNumericIntegerLookup #end {
     } //translate
 
     public function compose( _position:Vector, _rotation:Float, _scale:Vector ) {
-
-        var _diff = _rotation - _last_rotation;
-
+        
         identity();
 
         scale( _scale.x, _scale.y );
-        rotate( _diff );
+        rotate( _rotation );
         makeTranslation( _position.x, _position.y );
-
-        _last_rotation = _rotation;
 
     } //compose
 

--- a/hxcollision/shapes/Shape.hx
+++ b/hxcollision/shapes/Shape.hx
@@ -94,9 +94,7 @@ class Shape {
 
     function refresh_transform() {
 
-        _transformMatrix.rotate( _rotation_radians );
-
-        _transformMatrix.compose( _position, _rotation, _scale );
+        _transformMatrix.compose( _position, _rotation_radians, _scale );
         _transformed = false;
 
     }


### PR DESCRIPTION
- Absolute rotation, because changing position was making the shape
rotate again
- Removed redundant _transformMatrix.rotate( _rotation_radians ); in
Matrix.refresh_transform
- Change _rotation to _rotation_radians in refresh_transform